### PR TITLE
Fixing Notice SSL_VERIFYHOST no longer accepts 1

### DIFF
--- a/Klarna.php
+++ b/Klarna.php
@@ -550,6 +550,8 @@ class Klarna
             $this->_url['scheme']
         );
 
+        $sslCertificateMatchHost = 2;
+        $this->xmlrpc->setSSLVerifyHost($sslCertificateMatchHost);
         $this->xmlrpc->request_charset_encoding = 'ISO-8859-1';
     }
 


### PR DESCRIPTION
This change are fixing a Notice:
Notice: curl_setopt() [function.curl-setopt<\/a>]: CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead in \/Users\/tshabatyn\/Projects\/DW\/lib\/Klarna\/transport\/xmlrpc-3.0.0.beta\/lib\/xmlrpc.inc on line 1620
